### PR TITLE
Handle missing profile pictures when updating users

### DIFF
--- a/users/views.py
+++ b/users/views.py
@@ -66,7 +66,9 @@ def user_detail(request, user_id):
             if profile_picture:
                 if user.profile_picture:
                     user.profile_picture.close()
-                    os.remove(user.profile_picture.path)
+                    old_picture_path = user.profile_picture.path
+                    if os.path.isfile(old_picture_path):
+                        os.remove(old_picture_path)
                 user.profile_picture = profile_picture
             user.phone = request.POST.get("phone")
             user.address = request.POST.get("address")


### PR DESCRIPTION
## Summary
- prevent profile picture updates from failing when the existing file is missing
- only attempt to remove the old picture if the file still exists

## Testing
- no automated tests were run

------
https://chatgpt.com/codex/tasks/task_e_68f60ea60fd48329992cf73964491c25