### PR TITLE
Safely handle missing profile pictures when updating users

### DIFF
--- a/users/views.py
+++ b/users/views.py
@@ -66,7 +66,10 @@ def user_detail(request, user_id):
             if profile_picture:
                 if user.profile_picture:
                     user.profile_picture.close()
-                    os.remove(user.profile_picture.path)
+                    old_picture_name = user.profile_picture.name
+                    storage = user.profile_picture.storage
+                    if old_picture_name and storage.exists(old_picture_name):
+                        storage.delete(old_picture_name)
                 user.profile_picture = profile_picture
             user.phone = request.POST.get("phone")
             user.address = request.POST.get("address")


### PR DESCRIPTION
## Summary
- use the storage backend to check for the existing profile picture before removing it
- delete the old profile picture through the storage backend when it exists

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f60ea60fd48329992cf73964491c25