### PR TITLE
Gracefully handle missing profile pictures during updates

### DIFF
--- a/users/views.py
+++ b/users/views.py
@@ -64,9 +64,23 @@ def user_detail(request, user_id):
             user.date_of_birth = datetime.strptime(date_of_birth, "%Y-%m-%d")
             profile_picture = request.FILES.get("profile_picture")
             if profile_picture:
-                if user.profile_picture:
-                    user.profile_picture.close()
-                    os.remove(user.profile_picture.path)
+                existing_picture = getattr(user, "profile_picture", None)
+                if existing_picture:
+                    try:
+                        old_picture_name = existing_picture.name
+                    except (FileNotFoundError, ValueError):
+                        old_picture_name = None
+                    if old_picture_name:
+                        try:
+                            storage = existing_picture.storage
+                        except FileNotFoundError:
+                            storage = None
+                        if storage:
+                            try:
+                                if storage.exists(old_picture_name):
+                                    storage.delete(old_picture_name)
+                            except FileNotFoundError:
+                                pass
                 user.profile_picture = profile_picture
             user.phone = request.POST.get("phone")
             user.address = request.POST.get("address")


### PR DESCRIPTION
## Summary
- guard profile picture cleanup with try/except to avoid crashing when the file is missing
- skip deletion when storage or old file name cannot be determined

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f60ea60fd48329992cf73964491c25